### PR TITLE
fix join link underline not appearing in safari

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -74,7 +74,8 @@ strong {
 }
 
 .link {
-  text-decoration: underline var(--cyber-gold);
+  text-decoration-line: underline;
+  text-decoration-color: var(--cyber-gold);
 }
 
 .link:hover {


### PR DESCRIPTION
Webkit/safari apparently *requires* text-decoration to be split up into 2 separate declarations