### PR TITLE
fix: fix ordering in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 next-env.d.ts
 
 # vscode
+.vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
-.vscode/*
+


### PR DESCRIPTION
## Summary

Changed the order of the the .vscode ignore's in the .gitignore file because originally the exempted items
```
!.vscode/extensions.json
!.vscode/settings.json
```
came before 
```
.vscode/*
```
meaning they were still being ignored
> An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. 
https://git-scm.com/docs/gitignore

## Test Plan
I tested by first running:
```
git rm -r --cached .vscode/
```
to remove the cached .vscode directory and then I ran git status on both the original .gitignore and the modified one and found that git only detects the files .vscode/extensions.json and .vscode/settings.json for staging if the .gitignore is set up in the modified way